### PR TITLE
implemented multi query bulk request

### DIFF
--- a/snmp-server.py
+++ b/snmp-server.py
@@ -869,12 +869,15 @@ def snmp_server(host, port, oids):
                 oid_items.append((oid_to_bytes(oid), oid_value))
 
             elif pdu_type == ASN1_GET_BULK_REQUEST_PDU:
-                oid = request_result[6][1]
+                requested_oids = request_result[6:]
                 for i in range(0, max_repetitions):
-                    error_status, error_index, oid, oid_value = handle_get_next_request(oids, oid)
-                    if isinstance(oid_value, types.FunctionType):
-                        oid_value = oid_value(oid)
-                    oid_items.append((oid_to_bytes(oid), oid_value))
+                    for idx, val in enumerate(requested_oids):
+                        oid = val[1]
+                        error_status, error_index, oid, oid_value = handle_get_next_request(oids, oid)
+                        if isinstance(oid_value, types.FunctionType):
+                            oid_value = oid_value(oid)
+                        oid_items.append((oid_to_bytes(oid), oid_value))
+                        requested_oids[idx] = ('OID', oid)
 
             elif pdu_type == ASN1_SET_REQUEST_PDU:
                 if len(request_result) < 8:


### PR DESCRIPTION
I implemented multi bulk requests to queries such as:

`snmpbulkget -v 2c -Cr10 -On -c public localhost 1.3.6.1.2.1.2.2.1.2 1.3.6.1.2.1.2.2.1.3 1.3.6.1.2.1.2.2.1.7 1.3.6.1.2.1.2.2.1.8`

This should produce results as:

.1.3.6.1.2.1.2.2.1.2.1 = STRING: GigabitEthernet0/0
.1.3.6.1.2.1.2.2.1.3.1 = INTEGER: ethernetCsmacd(6)
.1.3.6.1.2.1.2.2.1.7.1 = INTEGER: up(1)
.1.3.6.1.2.1.2.2.1.8.1 = INTEGER: down(2)
.1.3.6.1.2.1.2.2.1.2.2 = STRING: Null0
.1.3.6.1.2.1.2.2.1.3.2 = INTEGER: other(1)
.1.3.6.1.2.1.2.2.1.7.2 = INTEGER: up(1)
.1.3.6.1.2.1.2.2.1.8.2 = INTEGER: up(1)
.1.3.6.1.2.1.2.2.1.2.3 = STRING: GigabitEthernet1/0/1
.1.3.6.1.2.1.2.2.1.3.3 = INTEGER: ethernetCsmacd(6)
.1.3.6.1.2.1.2.2.1.7.3 = INTEGER: up(1)
.1.3.6.1.2.1.2.2.1.8.3 = INTEGER: up(1)
.1.3.6.1.2.1.2.2.1.2.4 = STRING: unrouted VLAN 1
.1.3.6.1.2.1.2.2.1.3.4 = INTEGER: propVirtual(53)
.1.3.6.1.2.1.2.2.1.7.4 = INTEGER: testing(3)
.1.3.6.1.2.1.2.2.1.8.4 = INTEGER: unknown(4)


