### PR TITLE
Update to support Python3.10 Iterable

### DIFF
--- a/snmp-server.py
+++ b/snmp-server.py
@@ -15,8 +15,12 @@ import string
 import struct
 import sys
 import types
-from collections import Iterable
 from contextlib import closing
+
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 try:
     from StringIO import StringIO


### PR DESCRIPTION
In Python 3.10<, `Iterable` is moved to `collections.abc`

Nothing else needs changing to support 3.10< for now.